### PR TITLE
add phase-specific classes, only show cloud-edith-link on Test

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SRF Browser Extension",
   "description": "Little helper for SRF developers and CMS users",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "action": {
     "default_popup": "popup.html"
   },

--- a/src/popup.css
+++ b/src/popup.css
@@ -218,12 +218,21 @@ header h1 {
 
 .js-dev-only,
 .js-page-actions,
-.js-article-actions {
+.js-article-actions,
+.js-test-only {
     display: none;
 }
 
 [data-mode^='dev'] .js-dev-only {
     display: block;
+}
+
+[data-phase^='test'] .js-test-only {
+    display: block;
+}
+
+[data-phase^='test'] .js-not-on-test {
+    display: none;
 }
 
 [data-content-class^='landingpage'] .js-page-actions {

--- a/src/popup.html
+++ b/src/popup.html
@@ -6,7 +6,7 @@
     <link href="popup.css" rel="stylesheet" />
 </head>
 
-<body>
+<body data-mode="" data-phase="" data-content-class="">
     <div class="container">
         <header class="l-full-width">
             <img src="srf.svg" width="56px" />
@@ -69,12 +69,16 @@
                 <div class="section__content">
                     <ul class="links">
                         <li>
-                            <a class="link link--button link--replace-url" target="_blank" data-href="$NORA_URL/ui/$PORTAL/articles/$ID" href="">
+                            <a class="link link--button link--replace-url js-not-on-test" target="_blank" data-href="$NORA_URL/ui/$PORTAL/articles/$ID" href="">
+                                <img class="link__icon" src="Edith.svg" />
+                                In Edith bearbeiten
+                            </a>
+                            <a class="link link--button link--replace-url js-test-only" target="_blank" data-href="$NORA_URL/ui/$PORTAL/articles/$UUID" href="">
                                 <img class="link__icon" src="Edith.svg" />
                                 In Edith bearbeiten
                             </a>
                         </li>
-                        <li class="js-dev-only">
+                        <li class="js-dev-only js-not-on-test">
                             <a class="link link--button link--replace-url" target="_blank" data-href="$NORA_URL/ui/$PORTAL/articles/$UUID" href="">
                                 <img class="link__icon" src="Edith.svg" />
                                 In Edith bearbeiten (☁)

--- a/src/popup.js
+++ b/src/popup.js
@@ -121,6 +121,8 @@ const getContentInfo = () => {
 
       const { urn, phase, portalUrn, hasTicker, businessUnit, uuid, location } = response;
 
+      document.body.setAttribute('data-phase', phase.toLowerCase());
+
       if (urn) {
         const [,, contentClass, contentId] = urn.split(':');
         onContentIdFound(contentId, phase, portalUrn, businessUnit, uuid);


### PR DESCRIPTION
Problem:
On TEST, we force "cloud articles". In the extension we show the non-cloud edith link by default, one has to switch to dev mode to see the cloud link. 

Solution:
Introduce data-phase on the body, in combination with phase-specific classes we can show/hide extra links for tests.